### PR TITLE
Add new projects

### DIFF
--- a/Rpssl.sln
+++ b/Rpssl.sln
@@ -7,21 +7,45 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{DE88F719-8E4
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rpssl.Api", "src\Rpssl.Api\Rpssl.Api.csproj", "{A0CA5D8F-0514-42CB-9348-D0E76AC8A661}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rpssl.Domain", "src\Rpssl.Domain\Rpssl.Domain.csproj", "{53FC4DF1-66BF-418E-9482-8D0F3B8DE087}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rpssl.Application", "src\Rpssl.Application\Rpssl.Application.csproj", "{1BB0F88E-4024-4220-B031-CCEE72753B95}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rpssl.Infrastructure", "src\Rpssl.Infrastructure\Rpssl.Infrastructure.csproj", "{18838AFA-2832-43F7-93F0-423FB7CAA58E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{A0CA5D8F-0514-42CB-9348-D0E76AC8A661}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A0CA5D8F-0514-42CB-9348-D0E76AC8A661}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A0CA5D8F-0514-42CB-9348-D0E76AC8A661}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A0CA5D8F-0514-42CB-9348-D0E76AC8A661}.Release|Any CPU.Build.0 = Release|Any CPU
+		{53FC4DF1-66BF-418E-9482-8D0F3B8DE087}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{53FC4DF1-66BF-418E-9482-8D0F3B8DE087}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{53FC4DF1-66BF-418E-9482-8D0F3B8DE087}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{53FC4DF1-66BF-418E-9482-8D0F3B8DE087}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1BB0F88E-4024-4220-B031-CCEE72753B95}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1BB0F88E-4024-4220-B031-CCEE72753B95}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1BB0F88E-4024-4220-B031-CCEE72753B95}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1BB0F88E-4024-4220-B031-CCEE72753B95}.Release|Any CPU.Build.0 = Release|Any CPU
+		{18838AFA-2832-43F7-93F0-423FB7CAA58E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{18838AFA-2832-43F7-93F0-423FB7CAA58E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{18838AFA-2832-43F7-93F0-423FB7CAA58E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{18838AFA-2832-43F7-93F0-423FB7CAA58E}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{A0CA5D8F-0514-42CB-9348-D0E76AC8A661} = {DE88F719-8E4C-4D06-8C1B-D1063536BEA3}
+		{53FC4DF1-66BF-418E-9482-8D0F3B8DE087} = {DE88F719-8E4C-4D06-8C1B-D1063536BEA3}
+		{1BB0F88E-4024-4220-B031-CCEE72753B95} = {DE88F719-8E4C-4D06-8C1B-D1063536BEA3}
+		{18838AFA-2832-43F7-93F0-423FB7CAA58E} = {DE88F719-8E4C-4D06-8C1B-D1063536BEA3}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {481E0212-DFA0-403E-A73B-C40D3783594F}
 	EndGlobalSection
 EndGlobal

--- a/src/Rpssl.Api/Program.cs
+++ b/src/Rpssl.Api/Program.cs
@@ -1,18 +1,28 @@
+using Rpssl.Application;
+using Rpssl.Infrastructure;
+using Serilog;
+
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
+builder.Services
+    .AddApplication()
+    .AddInfrastructure();
+
+builder.Host.UseSerilog((context, configuration) =>
+    configuration.ReadFrom.Configuration(context.Configuration));
+
 var app = builder.Build();
 
-// Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
     app.UseSwaggerUI();
 }
+
+app.UseSerilogRequestLogging();
 
 app.UseHttpsRedirection();
 

--- a/src/Rpssl.Api/Rpssl.Api.csproj
+++ b/src/Rpssl.Api/Rpssl.Api.csproj
@@ -8,7 +8,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.19" />
+    <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Rpssl.Application\Rpssl.Application.csproj" />
+    <ProjectReference Include="..\Rpssl.Infrastructure\Rpssl.Infrastructure.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Rpssl.Api/appsettings.json
+++ b/src/Rpssl.Api/appsettings.json
@@ -1,9 +1,26 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  },
-  "AllowedHosts": "*"
+    "Serilog": {
+        "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.File" ],
+        "MinimumLevel": {
+            "Default": "Information",
+            "Override": {
+                "Microsoft": "Warning",
+                "System": "Warning"
+            }
+        },
+        "WriteTo": [
+            { "Name": "Console" },
+            {
+                "Name": "File",
+                "Args": {
+                    "path": "/logs/log-.txt",
+                    "rollingInterval": "Day",
+                    "rollOnFileSizeLimit": true,
+                    "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact"
+                }
+            }
+        ],
+        "Enrich": [ "FromLogContext", "WithMachineName", "WithThreadId" ]
+    },
+    "AllowedHosts": "*"
 }

--- a/src/Rpssl.Application/DependencyInjection.cs
+++ b/src/Rpssl.Application/DependencyInjection.cs
@@ -1,0 +1,20 @@
+﻿using FluentValidation;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Rpssl.Application;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddApplication(this IServiceCollection services)
+    {
+        var assembly = typeof(DependencyInjection).Assembly;
+
+        services.AddMediatR(configuration => 
+            configuration.RegisterServicesFromAssembly(
+                typeof(DependencyInjection).Assembly));
+
+        services.AddValidatorsFromAssembly(assembly);
+
+        return services;
+    }
+}

--- a/src/Rpssl.Application/Rpssl.Application.csproj
+++ b/src/Rpssl.Application/Rpssl.Application.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
+    <PackageReference Include="MediatR" Version="13.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Rpssl.Domain\Rpssl.Domain.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Rpssl.Domain/Rpssl.Domain.csproj
+++ b/src/Rpssl.Domain/Rpssl.Domain.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/Rpssl.Infrastructure/DependencyInjection.cs
+++ b/src/Rpssl.Infrastructure/DependencyInjection.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace Rpssl.Infrastructure;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddInfrastructure(this IServiceCollection services)
+    {
+        return services;
+    }
+}

--- a/src/Rpssl.Infrastructure/Rpssl.Infrastructure.csproj
+++ b/src/Rpssl.Infrastructure/Rpssl.Infrastructure.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Add new projects and configure Serilog logging

Updated the solution to include `Rpssl.Domain`, `Rpssl.Application`, and `Rpssl.Infrastructure`. Modified `Program.cs` to register application and infrastructure services, and configured Serilog for logging. Updated `Rpssl.Api.csproj` to include `Serilog.AspNetCore` and project references. Revised `appsettings.json` for Serilog settings.
Created `DependencyInjection.cs` in both `Rpssl.Application` and `Rpssl.Infrastructure` for service registration. New project files created for `Rpssl.Application`, `Rpssl.Domain`, and `Rpssl.Infrastructure`, all targeting .NET 8.0.