### PR TITLE
Update API response types for error handling

### DIFF
--- a/src/Rpssl.Api/Controllers/ChoicesController.cs
+++ b/src/Rpssl.Api/Controllers/ChoicesController.cs
@@ -22,7 +22,7 @@ public class ChoicesController(ISender mediator) : ControllerBase
     [ProducesResponseType(typeof(IReadOnlyList<ChoiceDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(Error), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(Error), StatusCodes.Status404NotFound)]
-    [ProducesResponseType(typeof(Error), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(Error), StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(typeof(Error), StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetAll(CancellationToken ct)
     {
@@ -36,7 +36,7 @@ public class ChoicesController(ISender mediator) : ControllerBase
     [ProducesResponseType(typeof(ChoiceDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(Error), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(Error), StatusCodes.Status404NotFound)]
-    [ProducesResponseType(typeof(Error), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(Error), StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(typeof(Error), StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetById(int id, CancellationToken ct)
     {

--- a/src/Rpssl.Api/Controllers/GameController.cs
+++ b/src/Rpssl.Api/Controllers/GameController.cs
@@ -29,7 +29,7 @@ public class GameController(ISender mediator) : ControllerBase
     [ProducesResponseType(typeof(GameResultDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(Error), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(Error), StatusCodes.Status404NotFound)]
-    [ProducesResponseType(typeof(Error), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(Error), StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(typeof(Error), StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> Play([FromBody] PlayRequest request, CancellationToken ct)
     {

--- a/src/Rpssl.Api/Controllers/StatsController.cs
+++ b/src/Rpssl.Api/Controllers/StatsController.cs
@@ -22,7 +22,7 @@ public class StatsController(ISender mediator) : ControllerBase
     [ProducesResponseType(typeof(StatsDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(Error), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(Error), StatusCodes.Status404NotFound)]
-    [ProducesResponseType(typeof(Error), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(Error), StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(typeof(Error), StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> Get(CancellationToken ct)
     {


### PR DESCRIPTION
Removed 409 Conflict responses and added 401 Unauthorized for ChoicesController, GameController, and StatsController. This change enhances the clarity of error handling in the API documentation, explicitly addressing unauthorized access for these endpoints.